### PR TITLE
Changing full admin role target for assumption to appropriate role.

### DIFF
--- a/templates/assume_full_admin_management.tpl
+++ b/templates/assume_full_admin_management.tpl
@@ -7,7 +7,7 @@
            "sts:AssumeRole"
         ],
         "Resource":[  
-           "arn:aws:iam::${aws_account_id}:role/${project}-management-org-admin"
+           "arn:aws:iam::${aws_account_id}:role/${project}-full-admin-management"
         ]
      }
   ]


### PR DESCRIPTION
Tech overview:

Changed template to assume full admin role for the full admin group to:
```
        "Resource":[  
           "arn:aws:iam::${aws_account_id}:role/${project}-full-admin-management"
        ]
```